### PR TITLE
updating php version dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     }
   ],
   "require": {
-    "php": "^7.4",
+    "php": ">=7.4",
     "yiisoft/yii2": "~2.0.0",
     "bacon/bacon-qr-code": "~2.0",
     "pragmarx/google2fa": "^8.0"


### PR DESCRIPTION
The extension just works on PHP 8 as far as I can see, so make the php requirement reflect that, so it can be used on newer PHP versions.